### PR TITLE
changed go.mod package url

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module octoclient
+module github.com/finbox-in/octoclient
 
 go 1.20
 


### PR DESCRIPTION
changed package name from octoclient to github.com/finbox-in/octoclient
So that it can be used in packages 